### PR TITLE
added support for checking if installed on mac or not

### DIFF
--- a/pywalfox/bin/main.sh
+++ b/pywalfox/bin/main.sh
@@ -1,3 +1,10 @@
 #!/usr/bin/env bash
 
-python -m pywalfox start || python3 -m pywalfox start || python2.7 -m pywalfox start
+# Checks OS Version Number
+macOS=$(sw_vers -productVersion)
+if [[ ${#macOS} > 0  ]]; then
+    PATH="$PATH:/usr/local/bin"
+    pywalfox start
+fi
+
+python -m pywalfox start || python3 -m pywalfox start || python2.7 -m pywalfox start || python3.9 -m pywalfox start


### PR DESCRIPTION
The `main.sh` checks wether pywalfox is being installed onto MacOS or not. 

Tried it on my computer and works fully.