### PR TITLE
feat(bin): support isolated python environments

### DIFF
--- a/pywalfox/bin/main.sh
+++ b/pywalfox/bin/main.sh
@@ -7,4 +7,4 @@ if [[ ${#macOS} > 0  ]]; then
     pywalfox start
 fi
 
-python -m pywalfox start || python3 -m pywalfox start || python2.7 -m pywalfox start || python3.9 -m pywalfox start
+python -m pywalfox start || python3 -m pywalfox start || python2.7 -m pywalfox start || python3.9 -m pywalfox start || pywalfox start

--- a/pywalfox/bin/win.bat
+++ b/pywalfox/bin/win.bat
@@ -1,3 +1,3 @@
 @echo off
 
-python -m pywalfox start || python3 -m pywalfox start || python2.7 -m pywalfox start
+python -m pywalfox start || python3 -m pywalfox start || python2.7 -m pywalfox start || pywalfox start


### PR DESCRIPTION
Allows `pywalfox` to run when installed via isolated managers like `pipx` or `uv` where the module might not be visible to the global python path.