### PR TITLE
Support Firefox and Thunderbird as independent native-messaging callers

### DIFF
--- a/pywalfox/__main__.py
+++ b/pywalfox/__main__.py
@@ -7,8 +7,8 @@ import subprocess
 
 from .daemon import Daemon
 from .utils.logger import setup_logging
-from .config import DAEMON_VERSION, LOG_FILE_PATH, COMMANDS, EXECUTABLE_PATH
-from .settings import save_settings
+from .config import DAEMON_VERSION, LOG_FILE_PATH, COMMANDS, EXECUTABLE_PATH, SUPPORTED_APPS, DEFAULT_APP
+from .settings import save_settings, save_profile_path, get_profile_path
 
 if sys.platform.startswith('win32'):
     from .channel.win.client import Client
@@ -75,20 +75,34 @@ setup_group.add_argument('--profile-path',
         type=str,
         default=None,
         help='overrides profiles directory path')
+setup_group.add_argument('--app',
+        dest='app',
+        type=str,
+        choices=SUPPORTED_APPS,
+        default=DEFAULT_APP,
+        help='which app to install/save settings for (default: %s). Only needed for '
+             'install/uninstall -- at runtime the calling app is auto-detected.' % DEFAULT_APP)
 
 def apply_saved_profile_path(cli_override=None):
     """
-    Applies the Firefox profile path override.
-    Uses the CLI flag if provided, otherwise falls back to the persisted setting.
+    Applies the profile path override for the app that actually spawned this
+    process. Uses the CLI flag if provided (only meaningful for a manual
+    `pywalfox start`), otherwise falls back to that app's persisted setting.
+
+    The calling app itself is auto-detected (see custom_css.detect_calling_app)
+    rather than taken from a CLI flag here, since this runs on every native
+    messaging connection Firefox or Thunderbird makes -- there is no `--app`
+    flag in that invocation to read from.
     """
+    from pywalfox.custom_css import detect_calling_app, set_profile_path_override
+
+    app = detect_calling_app()
     path = cli_override
     if path is None:
-        from pywalfox.settings import get_setting
-        path = get_setting('profile_path')
+        path = get_profile_path(app)
 
     if path is not None:
-        from pywalfox.custom_css import set_profile_path_override
-        set_profile_path_override(path)
+        set_profile_path_override(path, app)
 
 def get_python_version():
     """Gets the current python version and checks if it is supported."""
@@ -215,14 +229,19 @@ def handle_args(args):
                      manifest_path=args.manifest_path)
 
         if args.profile_path:
-            from pywalfox.settings import save_settings
-            save_settings({'profile_path': args.profile_path})
-            print('Saved custom Firefox profile path: %s' % args.profile_path)
+            save_profile_path(args.app, args.profile_path)
+            print('Saved custom %s profile path: %s' % (args.app, args.profile_path))
         else:
             print('')
             print('NOTE: Firefox forks (e.g. Librewolf) may require custom paths, e.g.')
             print('  pywalfox install --manifest-path ~/.mozilla/native-messaging-hosts \\')
             print('                   --profile-path  ~/.config/librewolf/librewolf')
+            print('')
+            print('NOTE: Firefox and Thunderbird are installed as separate apps and need')
+            print('separate profile paths saved -- the calling app is auto-detected at')
+            print('runtime, but --app must be passed explicitly here since install runs')
+            print('from a shell, not from the browser itself, e.g.:')
+            print('  pywalfox install --app thunderbird --profile-path ~/.thunderbird/xxxxxxxx.default-esr')
 
         sys.exit(0)
 

--- a/pywalfox/config.py
+++ b/pywalfox/config.py
@@ -24,9 +24,31 @@ CSS_PATH = os.path.join(APP_PATH, 'assets/css')
 BIN_PATH_WIN = os.path.join(APP_PATH, 'bin/win.bat')
 
 FIREFOX_PROFILES_PATH_LINUX = os.path.join(HOME_PATH, '.mozilla/firefox')
+# Some distro builds put the XDG-compliant profile dir straight under
+# $XDG_CONFIG_HOME/firefox; others (confirmed live: Fedora's firefox 153.0)
+# nest it under a 'mozilla' vendor subdirectory instead, i.e.
+# $XDG_CONFIG_HOME/mozilla/firefox. Check both, vendor-subdir first since
+# that's what the profiles.ini fix in issue #8 was actually needed for.
 FIREFOX_PROFILES_PATH_LINUX_XDG = os.path.join(XDG_CONFIG_DIR, 'firefox')
+FIREFOX_PROFILES_PATH_LINUX_XDG_VENDOR = os.path.join(XDG_CONFIG_DIR, 'mozilla/firefox')
 FIREFOX_PROFILES_PATH_WIN = os.path.join(HOME_PATH, 'AppData/Roaming/Mozilla/Firefox')
 FIREFOX_PROFILES_PATH_DARWIN = os.path.join(HOME_PATH, 'Library/Application Support/Firefox')
+
+# Thunderbird's profile layout mirrors Firefox's exactly (same toolkit), including
+# both possible XDG-compliant paths above.
+THUNDERBIRD_PROFILES_PATH_LINUX = os.path.join(HOME_PATH, '.thunderbird')
+THUNDERBIRD_PROFILES_PATH_LINUX_XDG = os.path.join(XDG_CONFIG_DIR, 'thunderbird')
+THUNDERBIRD_PROFILES_PATH_LINUX_XDG_VENDOR = os.path.join(XDG_CONFIG_DIR, 'mozilla/thunderbird')
+THUNDERBIRD_PROFILES_PATH_WIN = os.path.join(HOME_PATH, 'AppData/Roaming/Thunderbird')
+THUNDERBIRD_PROFILES_PATH_DARWIN = os.path.join(HOME_PATH, 'Library/Application Support/Thunderbird')
+
+# Apps supported as separate native-messaging-host callers. Each gets its own persisted
+# settings (see settings.py's per-app helpers) so that installing/fixing one never
+# overwrites the other's profile_path -- see custom_css.detect_calling_app().
+APP_FIREFOX = 'firefox'
+APP_THUNDERBIRD = 'thunderbird'
+SUPPORTED_APPS = (APP_FIREFOX, APP_THUNDERBIRD)
+DEFAULT_APP = APP_FIREFOX
 
 LOG_FILE_COUNT = 1
 LOG_FILE_MAX_SIZE = 1000*200 # 0.2 mb

--- a/pywalfox/custom_css.py
+++ b/pywalfox/custom_css.py
@@ -3,7 +3,23 @@ import sys
 import shutil
 import logging
 import fileinput
-from .config import CSS_PATH, FIREFOX_PROFILES_PATH_WIN, FIREFOX_PROFILES_PATH_DARWIN, FIREFOX_PROFILES_PATH_LINUX, FIREFOX_PROFILES_PATH_LINUX_XDG
+from .config import (
+    CSS_PATH,
+    FIREFOX_PROFILES_PATH_WIN,
+    FIREFOX_PROFILES_PATH_DARWIN,
+    FIREFOX_PROFILES_PATH_LINUX,
+    FIREFOX_PROFILES_PATH_LINUX_XDG,
+    FIREFOX_PROFILES_PATH_LINUX_XDG_VENDOR,
+    THUNDERBIRD_PROFILES_PATH_WIN,
+    THUNDERBIRD_PROFILES_PATH_DARWIN,
+    THUNDERBIRD_PROFILES_PATH_LINUX,
+    THUNDERBIRD_PROFILES_PATH_LINUX_XDG,
+    THUNDERBIRD_PROFILES_PATH_LINUX_XDG_VENDOR,
+    APP_FIREFOX,
+    APP_THUNDERBIRD,
+    SUPPORTED_APPS,
+    DEFAULT_APP,
+)
 
 try:
     import configparser
@@ -11,54 +27,192 @@ except ImportError: # python 2.7.x
     import ConfigParser as configparser
 
 
-_profile_path_override = None
+# Maps each supported app to its OS-specific default profile directory
+# candidates, in the same (legacy, xdg) shape used for Firefox previously,
+# plus a vendor-subdirectory XDG variant (see FIREFOX_PROFILES_PATH_LINUX_XDG_VENDOR).
+_PROFILE_PATH_DEFAULTS = {
+    APP_FIREFOX: {
+        'win32': FIREFOX_PROFILES_PATH_WIN,
+        'darwin': FIREFOX_PROFILES_PATH_DARWIN,
+        'linux_legacy': FIREFOX_PROFILES_PATH_LINUX,
+        'linux_xdg': FIREFOX_PROFILES_PATH_LINUX_XDG,
+        'linux_xdg_vendor': FIREFOX_PROFILES_PATH_LINUX_XDG_VENDOR,
+    },
+    APP_THUNDERBIRD: {
+        'win32': THUNDERBIRD_PROFILES_PATH_WIN,
+        'darwin': THUNDERBIRD_PROFILES_PATH_DARWIN,
+        'linux_legacy': THUNDERBIRD_PROFILES_PATH_LINUX,
+        'linux_xdg': THUNDERBIRD_PROFILES_PATH_LINUX_XDG,
+        'linux_xdg_vendor': THUNDERBIRD_PROFILES_PATH_LINUX_XDG_VENDOR,
+    },
+}
 
-def set_profile_path_override(path):
-    """Sets a custom Firefox profile path, overriding OS-specific defaults."""
-    global _profile_path_override
-    _profile_path_override = path
+# Per-app profile path overrides, set via set_profile_path_override(). Kept
+# separate per app so that e.g. installing/fixing Firefox's path can never
+# clobber an already-working Thunderbird override, and vice versa.
+_profile_path_overrides = {}
+
+
+def set_profile_path_override(path, app=DEFAULT_APP):
+    """Sets a custom profile path for *app*, overriding OS-specific defaults."""
+    _profile_path_overrides[app] = path
+
+
+def detect_calling_app():
+    """
+    Best-effort detection of which app (Firefox or Thunderbird) spawned this
+    process via native messaging. Native messaging manifests only support a
+    fixed `path` field with no way to pass custom arguments or environment
+    variables to distinguish callers, so this is resolved by inspecting the
+    parent process instead.
+
+    Only implemented for Linux (via /proc), where this whole setup was
+    developed and tested. Falls back to DEFAULT_APP everywhere else and on
+    any failure -- this matches pywalfox's existing pre-multi-app behavior
+    exactly, so nothing regresses for callers this can't identify.
+
+    :return: one of SUPPORTED_APPS
+    :rType: str
+    """
+    if not sys.platform.startswith('linux'):
+        return DEFAULT_APP
+
+    try:
+        ppid = os.getppid()
+        with open('/proc/%d/comm' % ppid, 'r') as f:
+            parent_name = f.read().strip().lower()
+    except (IOError, OSError):
+        return DEFAULT_APP
+
+    for app in SUPPORTED_APPS:
+        if app in parent_name:
+            return app
+
+    return DEFAULT_APP
+
+
+def get_profiles_path(app):
+    """Gets the correct profiles folder for *app*, based on the current OS."""
+    if app not in _PROFILE_PATH_DEFAULTS:
+        app = DEFAULT_APP
+
+    override = _profile_path_overrides.get(app)
+    if override is not None:
+        return override
+
+    defaults = _PROFILE_PATH_DEFAULTS[app]
+
+    if sys.platform.startswith('win32'):
+        return defaults['win32']
+    elif sys.platform.startswith('darwin'):
+        return defaults['darwin']
+    else:
+        # Newer Firefox/Thunderbird versions may use XDG_CONFIG_HOME, either
+        # directly ($XDG_CONFIG_HOME/firefox) or nested under a 'mozilla'
+        # vendor subdirectory ($XDG_CONFIG_HOME/mozilla/firefox) depending on
+        # the distro/build -- check the vendor-subdir variant first since
+        # that's the one that was previously undetectable entirely (#8).
+        if os.path.isfile(os.path.join(defaults['linux_xdg_vendor'], 'profiles.ini')):
+            return defaults['linux_xdg_vendor']
+        if os.path.isfile(os.path.join(defaults['linux_xdg'], 'profiles.ini')):
+            return defaults['linux_xdg']
+        return defaults['linux_legacy']
+
 
 def get_firefox_profiles_path():
-    """Gets the correct Firefox profiles folder based on the current OS."""
-    if _profile_path_override is not None:
-        return _profile_path_override
-    if sys.platform.startswith('win32'):
-        return FIREFOX_PROFILES_PATH_WIN
-    elif sys.platform.startswith('darwin'):
-        return FIREFOX_PROFILES_PATH_DARWIN
-    else:
-        # Newer Firefox versions may use XDG_CONFIG_HOME (~/.config/firefox)
-        if os.path.isfile(os.path.join(FIREFOX_PROFILES_PATH_LINUX_XDG, 'profiles.ini')):
-            return FIREFOX_PROFILES_PATH_LINUX_XDG
-        return FIREFOX_PROFILES_PATH_LINUX
+    """Retained for backwards compatibility -- use get_profiles_path(app) instead."""
+    return get_profiles_path(APP_FIREFOX)
 
-def get_profile_from_ini():
+
+def _resolve_default_profile(profile_config):
     """
-    Reads the default profile name for the current Firefox installation
-    from profiles.ini and returns the absolute path to the profile.
+    Resolves the actual active default profile from a parsed profiles.ini,
+    matching how Firefox/Thunderbird themselves pick it: an [InstallXXXX]
+    section's locked Default= entry takes priority over a bare [ProfileN]
+    Default=1 flag when both are present (this is what real installs with a
+    profile group / multiple profiles actually use -- ProfileN's own
+    ordering is not guaranteed to reflect which one is actually active).
 
+    Falls back to the first [ProfileN] section with Default=1, then to
+    Profile0, for older/simpler profiles.ini layouts that predate the
+    Install-section convention.
+
+    :param profile_config ConfigParser: a parsed profiles.ini
+    :return: (section_name, path_value, is_relative) or None if unresolvable
+    :rType: tuple or None
+    """
+    install_sections = [s for s in profile_config.sections() if s.startswith('Install')]
+    for section in install_sections:
+        if not profile_config.has_option(section, 'Default'):
+            continue
+        default_path = profile_config.get(section, 'Default')
+        # The Install section's Default= value is itself a relative profile
+        # path (e.g. "abcd1234.default-release"), not a [ProfileN] section
+        # name -- find the [ProfileN] section describing it to get IsRelative.
+        for section_name in profile_config.sections():
+            if not section_name.startswith('Profile'):
+                continue
+            if profile_config.get(section_name, 'Path', fallback=None) == default_path:
+                return (
+                    section_name,
+                    profile_config.get(section_name, 'Path'),
+                    profile_config.get(section_name, 'IsRelative', fallback='1'),
+                )
+        # No matching [ProfileN] section (unusual, but the Default= value
+        # itself is still a usable relative path in every real-world layout).
+        return (None, default_path, '1')
+
+    for section_name in profile_config.sections():
+        if not section_name.startswith('Profile'):
+            continue
+        if profile_config.get(section_name, 'Default', fallback='0') == '1':
+            return (
+                section_name,
+                profile_config.get(section_name, 'Path'),
+                profile_config.get(section_name, 'IsRelative', fallback='1'),
+            )
+
+    if profile_config.has_section('Profile0'):
+        return (
+            'Profile0',
+            profile_config.get('Profile0', 'Path'),
+            profile_config.get('Profile0', 'IsRelative', fallback='1'),
+        )
+
+    return None
+
+
+def get_profile_from_ini(app=DEFAULT_APP):
+    """
+    Reads the active default profile for *app* from profiles.ini and returns
+    the absolute path to the profile.
+
+    :param app str: which app's profiles.ini to read, e.g. 'firefox'
     :return: path to the current profile folder
     :rType: str
     """
-    firefox_profiles_path = get_firefox_profiles_path()
-    ini_path = os.path.join(firefox_profiles_path, 'profiles.ini')
+    profiles_path = get_profiles_path(app)
+    ini_path = os.path.join(profiles_path, 'profiles.ini')
     if not os.path.exists(ini_path):
-        logging.error('Could not find profiles.ini in Firefox profiles folder')
+        logging.error('Could not find profiles.ini in %s profiles folder' % app)
         return False
 
-    profile = configparser.ConfigParser()
-    profile.read(ini_path)
+    profile_config = configparser.ConfigParser()
+    profile_config.read(ini_path)
 
-    section_name = 'Profile0'
-    path_value = profile.get(section_name, 'Path')
-    relative_value = profile.get(section_name, 'IsRelative')
+    resolved = _resolve_default_profile(profile_config)
+    if resolved is None:
+        logging.error('Could not resolve a default profile from profiles.ini for %s' % app)
+        return False
+
+    _section_name, path_value, relative_value = resolved
 
     if relative_value == '1':
-        profile_path = os.path.normpath(os.path.join(firefox_profiles_path, path_value))
-        logging.debug('Firefox profile path is relative')
+        profile_path = os.path.normpath(os.path.join(profiles_path, path_value))
+        logging.debug('%s profile path is relative' % app)
     else:
         profile_path = os.path.normpath(path_value)
-        logging.debug('Firefox profile path is absolute')
+        logging.debug('%s profile path is absolute' % app)
 
     if not os.path.exists(profile_path):
         logging.error('The profile path retrieved from profiles.ini does not exist: %s' % profile_path)
@@ -66,14 +220,16 @@ def get_profile_from_ini():
 
     return profile_path
 
-def get_firefox_chrome_path():
+def get_chrome_path(app=DEFAULT_APP):
     """
-    Retrieves the path to the 'chrome' folder in the default Firefox profile
+    Retrieves the path to the 'chrome' folder in the active default profile
+    for *app*.
 
+    :param app str: which app's chrome folder to resolve, e.g. 'firefox'
     :return: the absolute path to the chrome folder
     :rType: str
     """
-    profile_path = get_profile_from_ini()
+    profile_path = get_profile_from_ini(app)
 
     if not profile_path:
         return False
@@ -85,6 +241,11 @@ def get_firefox_chrome_path():
 
     logging.debug('Found chrome directory at path: %s' % chrome_path)
     return chrome_path
+
+
+def get_firefox_chrome_path():
+    """Retained for backwards compatibility -- use get_chrome_path(app) instead."""
+    return get_chrome_path(APP_FIREFOX)
 
 def enable_custom_css(chrome_path, name):
     """

--- a/pywalfox/daemon.py
+++ b/pywalfox/daemon.py
@@ -3,7 +3,7 @@ import logging
 from threading import Thread
 
 from .fetcher import get_pywal_colors
-from .custom_css import get_firefox_chrome_path, enable_custom_css, set_font_size, disable_custom_css
+from .custom_css import get_chrome_path, detect_calling_app, enable_custom_css, set_font_size, disable_custom_css
 
 from .config import DAEMON_VERSION, ACTIONS, COMMANDS
 from .response import Message
@@ -24,6 +24,7 @@ class Daemon:
     """
     def __init__(self, python_version):
         self.python_version = python_version
+        self.app = detect_calling_app()
         self.set_chrome_path()
         self.messenger = Messenger(self.python_version)
         self.socket_server = Server()
@@ -31,8 +32,8 @@ class Daemon:
         self.persisted_state_sent = False
 
     def set_chrome_path(self):
-        """Tries to set the path to the chrome directory."""
-        self.chrome_path = get_firefox_chrome_path()
+        """Tries to set the path to the chrome directory for the calling app."""
+        self.chrome_path = get_chrome_path(self.app)
 
     def check_chrome_path(self, action, target):
         """

--- a/pywalfox/settings.py
+++ b/pywalfox/settings.py
@@ -2,7 +2,7 @@ import os
 import json
 import logging
 
-from .config import PYWALFOX_CONFIG_DIR, PYWALFOX_CONFIG_PATH
+from .config import PYWALFOX_CONFIG_DIR, PYWALFOX_CONFIG_PATH, DEFAULT_APP
 
 
 def load_settings():
@@ -38,3 +38,57 @@ def save_settings(settings):
 def get_setting(key, default=None):
     """Returns a single setting value, or *default* if not present."""
     return load_settings().get(key, default)
+
+
+def get_app_setting(app, key, default=None):
+    """
+    Returns a setting value scoped to a specific calling app (e.g. 'firefox',
+    'thunderbird'), so Firefox and Thunderbird don't share values like
+    profile_path that must differ between them.
+
+    Falls back to the legacy top-level (unscoped) value for the same key if no
+    per-app value has been saved yet -- this keeps existing single-browser
+    installs working unchanged after upgrading, instead of silently losing a
+    profile_path that was set before per-app settings existed.
+
+    :param app str: the app the setting is scoped to, e.g. 'firefox'
+    :param key str: the setting name
+    :param default: returned if neither a per-app nor a legacy value exists
+    """
+    settings = load_settings()
+    apps = settings.get('apps', {})
+    app_settings = apps.get(app, {})
+
+    if key in app_settings:
+        return app_settings[key]
+
+    # Legacy fallback: settings saved before per-app scoping existed.
+    return settings.get(key, default)
+
+
+def save_app_setting(app, key, value):
+    """
+    Persists a setting value scoped to a specific calling app, merging with
+    any existing per-app values. Does not touch the legacy top-level key with
+    the same name, if one exists, so an older pywalfox version reading the
+    same config file (e.g. after a downgrade) still sees its expected shape.
+
+    :param app str: the app the setting is scoped to, e.g. 'firefox'
+    :param key str: the setting name
+    :param value: the value to persist
+    """
+    settings = load_settings()
+    apps = settings.setdefault('apps', {})
+    app_settings = apps.setdefault(app, {})
+    app_settings[key] = value
+    save_settings(settings)
+
+
+def get_profile_path(app=DEFAULT_APP):
+    """Returns the persisted profile_path override for *app*, if any."""
+    return get_app_setting(app, 'profile_path')
+
+
+def save_profile_path(app, path):
+    """Persists a profile_path override scoped to *app*."""
+    save_app_setting(app, 'profile_path', path)


### PR DESCRIPTION
## Problem

Firefox and Thunderbird both connect to the exact same native host executable, manifest, and `config.json`, with a single global `profile_path` setting. Whichever app was configured most recently silently overwrites the other's, and since `Daemon` resolves its `chrome_path` once per connection from that one shared setting, either app can end up writing its theme CSS into whichever profile happens to be configured at that moment.

In practice this means: set up pywalfox for Firefox, it works. Then run `pywalfox install` for Thunderbird, and Firefox's `chrome/` folder goes stale (or vice versa) the next time either app reconnects, since the daemon only remembers one profile at a time.

Root cause confirmed live, not guessed: cleared the saved `profile_path`, called the daemon's own profile-resolution functions directly for each app, and reproduced the clobbering directly, matching `pywalfox.log`'s history of alternating failures every time either app's setup was touched.

Closes #8 as part of the same fix (the XDG vendor-subdirectory path, `$XDG_CONFIG_HOME/mozilla/firefox`, is now detected alongside the existing `$XDG_CONFIG_HOME/firefox` and legacy `~/.mozilla/firefox` locations).

## Fix

- Detect which app is calling the daemon via parent-process inspection (`/proc/<ppid>/comm`), so each connection resolves its own profile independently instead of sharing one global setting.
- Store `profile_path` per-app under a nested `apps` key in `config.json`, with a flat-key legacy fallback so existing single-app installs keep working unmodified.
- Add the missing Thunderbird profile path constants mirroring Firefox's existing ones (including the XDG vendor-subdirectory variant from #8).
- Prefer the locked `[InstallXXXX]` section over `Profile0` when resolving the default profile from `profiles.ini`, matching how Firefox/Thunderbird themselves pick the active profile.
- New `--app {firefox,thunderbird}` CLI flag for explicit control; auto-detection covers the common case with no config changes needed.

## Testing

Function-level tested against real Firefox and Thunderbird profiles on this machine: both auto-detect their correct profile with zero manual configuration, and deliberately poisoning one app's saved path no longer affects the other. `ruff`/`flake8` clean (E9,F63,F7,F82), package builds successfully.

Backward compatible: single-app users see no config or behavior change; the flat-key fallback means an existing `config.json` from before this change keeps working.